### PR TITLE
Fixed an issue with "modulo 0" operator. Some methods in PID class re…

### DIFF
--- a/smithnormalform/ed.py
+++ b/smithnormalform/ed.py
@@ -43,6 +43,11 @@ class ED(pid.PID):
     def __mod__(self, x):
         return self.get_r(x)
 
+    def divides(self, x):
+        if self == self.getZero():
+            return x == self.getZero()
+        return self % x == self.getZero()
+
     # in a euclidean domain, the extended euclidean algorithm can be used
     # to find the extended_gcd, which makes this problem much easier
     def extended_gcd(a, b):

--- a/smithnormalform/pid.py
+++ b/smithnormalform/pid.py
@@ -48,14 +48,14 @@ class PID(ABC):
     def __mul__(self, x):
         pass
 
-    # returns the floored division of two elements of a PID
+    # returns True iff x = k * self for some k from the ring
     @abstractmethod
-    def __floordiv__(self, x):
+    def divides(self, x):
         pass
 
-    # returns the floored division remainder of two elements of a PID
+    # if x divides self and is not zero, returns the unique k satisfying self = k * x
     @abstractmethod
-    def __mod__(self, x):
+    def __floordiv__(self, x):
         pass
 
     # returns the additive identity of the ring
@@ -78,11 +78,7 @@ class PID(ABC):
 
     # returns True when this object is a unit multiple of x, otherwise False.
     def isUnitMultipleOf(self, x):
-        if not (self % x) == self.getZero():
-            return False
-        if not (self // x).isUnit():
-            return False
-        return True
+        return self.divides(x) and x.divides(self)
 
     # This should return a tuple (g, x, y) such where
     # - g is the gcd of self and x

--- a/smithnormalform/snfproblem.py
+++ b/smithnormalform/snfproblem.py
@@ -66,19 +66,9 @@ class SNFProblem:
         # then we check that diagonal elements divide each other until a zero
         # is found and then all remaining diagonal elements are zero
         diagLength = min(self.J.h, self.J.w)
-        if diagLength > 1:
-            lastDiag = self.J.get(0, 0)
-            seenZero = (lastDiag == zero)
-            for i in range(1, diagLength):
-                currentDiag = self.J.get(i, i)
-                if currentDiag == zero:
-                    seenZero = True
-
-                if seenZero and currentDiag != zero:
-                    return False
-
-                if not seenZero and currentDiag % lastDiag != zero:
-                    return False
+        for i in range(0, diagLength - 1):
+            if not self.J.get(i, i).divides(self.J.get(i + 1, i + 1)):
+                return False
 
         # if all of the checks pass then this is a valid completed SNF problem
         return True


### PR DESCRIPTION
…named, isValid algorithm simplified.

In a general PID there is no default modulo operation (one has equivalence classes modulo an ideal but it's not necessary here). The bug in https://github.com/corbinmcneill/SNF/issues/30 seemed to result from trying to perform "% 0" in integers.
Since "x % y == zero" comparison in general algorithm is used only for testing divisibility, I suggest adding an abstract "divides(self, x)" method to the PID class. By definition zero also divides zero, which may simplify notation in some places.